### PR TITLE
Update gemspecs to point at ActiveFedora 9.0.0

### DIFF
--- a/hydra-access-controls/hydra-access-controls.gemspec
+++ b/hydra-access-controls/hydra-access-controls.gemspec
@@ -18,10 +18,10 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = '>= 1.9.3'
 
-  gem.add_dependency 'activesupport'
-  gem.add_dependency "active-fedora", '~> 9.0.0.rc2'
-  gem.add_dependency 'cancancan'
-  gem.add_dependency 'deprecation'
+  gem.add_dependency 'activesupport', '~> 4.0'
+  gem.add_dependency "active-fedora", '~> 9.0.0'
+  gem.add_dependency 'cancancan', '~> 1.8'
+  gem.add_dependency 'deprecation', '~> 0.1.0'
   gem.add_dependency "blacklight", '~> 5.3'
 
   # sass-rails is typically generated into the app's gemfile by `rails new`
@@ -30,6 +30,6 @@ Gem::Specification.new do |gem|
   # declare a dependency on) sass-rails
   gem.add_dependency 'sass-rails'
 
-  gem.add_development_dependency "rake"
-  gem.add_development_dependency 'rspec'
+  gem.add_development_dependency "rake", '~> 10.1'
+  gem.add_development_dependency 'rspec' '~> 3.1'
 end

--- a/hydra-core/hydra-core.gemspec
+++ b/hydra-core/hydra-core.gemspec
@@ -18,13 +18,12 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = '>= 1.9.3'
 
-  gem.add_dependency "rails", '>= 3.2.3', '< 5'
-  gem.add_dependency 'block_helpers'
+  gem.add_dependency "rails", '~> 4.0'
   gem.add_dependency 'hydra-access-controls', version
   gem.add_dependency 'jettywrapper', '>= 2.0.0'
 
-  gem.add_development_dependency 'sqlite3'
-  gem.add_development_dependency 'yard'
-  gem.add_development_dependency 'rspec-rails'
-  gem.add_development_dependency 'factory_girl_rails'
+  gem.add_development_dependency 'sqlite3', '~> 1.3'
+  gem.add_development_dependency 'yard', '~> 0.8.7'
+  gem.add_development_dependency 'rspec-rails', '~> 3.1'
+  gem.add_development_dependency 'factory_girl_rails', '~> 4.2'
 end

--- a/hydra-core/spec/test_app_templates/Gemfile.extra
+++ b/hydra-core/spec/test_app_templates/Gemfile.extra
@@ -1,3 +1,2 @@
 gem 'rspec-rails', '~> 3.1', group: :test
 gem 'rspec-its'
-gem 'active-fedora', github: 'projecthydra/active_fedora', ref: 'c53b3e4'


### PR DESCRIPTION
Also added versions to gems that didn't have any. Fixes #192
Removed unused block_helpers depenency