### PR TITLE
Add version option to hydra:jetty generator

### DIFF
--- a/hydra-core/lib/generators/hydra/jetty_generator.rb
+++ b/hydra-core/lib/generators/hydra/jetty_generator.rb
@@ -11,7 +11,10 @@ Requires system('unzip... ') to work, probably won't work on Windows.
 
 """
 
+    class_option :version, type: :string, desc: 'The version of hydra-jetty to install'
+
     def download_jetty
+      Jettywrapper.hydra_jetty_version = options[:version] unless options[:version].nil?
       Jettywrapper.unzip
     end
 


### PR DESCRIPTION
Having an option to specify version in the generator allows Hydra 8 to install an older version than master and newer than 7.0.0 of hydra-jetty without hard coding a version, forcing a release of jettywrapper, or making the install instructions in Dive into Hydra too unwieldy.