### PR TITLE
Using Hydra::Controller::SearchBuilder

### DIFF
--- a/hydra-core/app/controllers/concerns/hydra/controller/controller_behavior.rb
+++ b/hydra-core/app/controllers/concerns/hydra/controller/controller_behavior.rb
@@ -16,12 +16,7 @@ module Hydra::Controller::ControllerBehavior
     rescue_from CanCan::AccessDenied, with: :deny_access
   end
 
-  # Override blacklight to produce a search_builder that has the current collection in context
-  def search_builder processor_chain = search_params_logic
-    super.tap { |builder| builder.current_ability = current_ability }
-  end
-
-   # get the currently configured user identifier.  Can be overridden to return whatever (ie. login, email, etc)
+  # get the currently configured user identifier.  Can be overridden to return whatever (ie. login, email, etc)
   # defaults to using whatever you have set as the Devise authentication_key
   def user_key
     current_user.user_key if current_user

--- a/hydra-core/app/controllers/concerns/hydra/controller/search_builder.rb
+++ b/hydra-core/app/controllers/concerns/hydra/controller/search_builder.rb
@@ -1,0 +1,9 @@
+module Hydra::Controller::SearchBuilder
+  extend ActiveSupport::Concern
+
+  # Override blacklight to produce a search_builder that has the current collection in context
+  def search_builder processor_chain = search_params_logic
+    super.tap { |builder| builder.current_ability = current_ability }
+  end
+
+end

--- a/hydra-core/lib/generators/hydra/templates/catalog_controller.rb
+++ b/hydra-core/lib/generators/hydra/templates/catalog_controller.rb
@@ -5,6 +5,7 @@ class CatalogController < ApplicationController
 
   include Blacklight::Catalog
   include Hydra::Controller::ControllerBehavior
+  include Hydra::Controller::SearchBuilder
   # These before_filters apply the hydra access controls
   before_filter :enforce_show_permissions, :only=>:show
   # This applies appropriate access controls to all solr queries


### PR DESCRIPTION
Creates a module for overriding Blacklight's search_builder method. This module can be included in any controller and is separate from Hydra::Controller::ControllerBehavior.

This has been tested against Sufia and corrects the problems found in projecthydra/sufia#953