### PR TITLE
Add Content Negotiation

### DIFF
--- a/hydra-access-controls/lib/hydra/config.rb
+++ b/hydra-access-controls/lib/hydra/config.rb
@@ -11,6 +11,8 @@ module Hydra
           self.permissions = value
         when :user_model
           self.user_model = value
+        when :id_to_resource_uri
+          self.id_to_resource_uri = value
         else
           raise "Unknown key"
       end
@@ -22,13 +24,25 @@ module Hydra
           permissions
         when :user_model
           user_model
+        when :id_to_resource_uri
+          id_to_resource_uri
         else
           raise "Unknown key #{key}"
       end
     end
 
     attr_reader :permissions
+    attr_writer :id_to_resource_uri
     attr_accessor :user_model
+
+    # This is purely used for translating an ID to user-facing URIs not used for
+    # persistence. Useful for storing RDF in Fedora but displaying their
+    # subjects in content negotiation as local to the application.
+    #
+    # @return [Lambda] a method to convert ID to a URI
+    def id_to_resource_uri
+      @id_to_resource_uri ||= ActiveFedora::Base.translate_id_to_uri
+    end
 
     def permissions= values
       @permissions.merge! values

--- a/hydra-core/app/models/concerns/hydra/content_negotiation.rb
+++ b/hydra-core/app/models/concerns/hydra/content_negotiation.rb
@@ -1,0 +1,35 @@
+module Hydra
+  module ContentNegotiation
+    def self.extended(document)
+      document.will_export_as(:nt, "application/n-triples")
+      document.will_export_as(:jsonld, "application/json")
+      document.will_export_as(:ttl, "text/turtle")
+    end
+
+    def export_as_nt
+      clean_graph.dump(:ntriples)
+    end
+
+    def export_as_jsonld
+      clean_graph.dump(:jsonld, :standard_prefixes => true)
+    end
+
+    def export_as_ttl
+      clean_graph.dump(:ttl)
+    end
+
+    private
+
+    def clean_graph
+      @clean_graph ||= clean_graph_repository.find(id)
+    end
+
+    def clean_graph_repository
+      CleanGraphRepository.new(connection)
+    end
+
+    def connection
+      ActiveFedora.fedora.clean_connection
+    end
+  end
+end

--- a/hydra-core/app/models/hydra/content_negotiation/clean_graph_repository.rb
+++ b/hydra-core/app/models/hydra/content_negotiation/clean_graph_repository.rb
@@ -1,0 +1,16 @@
+module Hydra::ContentNegotiation
+  # CleanGraphRepository has a #find interface which returns a graph for use
+  # with content negotiation.
+  class CleanGraphRepository
+    attr_reader :connection
+    def initialize(connection)
+      @connection = connection
+    end
+
+    def find(id)
+      ReplacingGraphFinder.new(
+        GraphFinder.new(connection, id)
+      ).graph
+    end
+  end
+end

--- a/hydra-core/app/models/hydra/content_negotiation/fedora_uri_replacer.rb
+++ b/hydra-core/app/models/hydra/content_negotiation/fedora_uri_replacer.rb
@@ -1,0 +1,46 @@
+module Hydra::ContentNegotiation
+  # Replaces Fedora URIs in a graph with a Hydra-configured alternative.
+  class FedoraUriReplacer
+    def initialize(fedora_base_uri, graph)
+      @fedora_base_uri = fedora_base_uri
+      @graph = graph
+    end
+
+    def run
+      RDF::Graph.new.insert(*replaced_objects)
+    end
+
+    private
+
+    attr_reader :fedora_base_uri, :graph
+
+    def replace_uri(uri)
+      id = ActiveFedora::Base.uri_to_id(uri)
+      RDF::URI(Hydra.config.id_to_resource_uri.call(id))
+    end
+
+    def replaced_objects
+      replaced_subjects.map do |statement|
+        if fedora_uri?(statement.object)
+          RDF::Statement.from([statement.subject, statement.predicate, replace_uri(statement.object)])
+        else
+          statement
+        end
+      end
+    end
+
+    def fedora_uri?(subject)
+      subject.to_s.start_with?(fedora_base_uri.to_s)
+    end
+
+    def replaced_subjects
+      graph.each_statement.to_a.map do |s|
+        if fedora_uri?(s.subject)
+          RDF::Statement.from([replace_uri(s.subject), s.predicate, s.object])
+        else
+          s
+        end
+      end
+    end
+  end
+end

--- a/hydra-core/app/models/hydra/content_negotiation/graph_finder.rb
+++ b/hydra-core/app/models/hydra/content_negotiation/graph_finder.rb
@@ -1,0 +1,18 @@
+module Hydra::ContentNegotiation
+  # Finds a graph given a connection and ID.
+  class GraphFinder
+    attr_reader :connection, :id
+    def initialize(connection, id)
+      @connection = connection
+      @id = id
+    end
+
+    def graph
+      connection.get(uri).graph
+    end
+
+    def uri
+      ActiveFedora::Base.id_to_uri(id)
+    end
+  end
+end

--- a/hydra-core/app/models/hydra/content_negotiation/replacing_graph_finder.rb
+++ b/hydra-core/app/models/hydra/content_negotiation/replacing_graph_finder.rb
@@ -1,0 +1,19 @@
+module Hydra::ContentNegotiation
+  # Decorator for Finder which replaces Fedora subjects in the graph with a 
+  # configured URI
+  class ReplacingGraphFinder < SimpleDelegator
+    def graph
+      graph_replacer.run
+    end
+
+    private
+
+    def graph_replacer
+      ::Hydra::ContentNegotiation::FedoraUriReplacer.new(base_uri, __getobj__.graph)
+    end
+
+    def base_uri
+      @base_uri ||= uri.gsub(/#{id}$/,'')
+    end
+  end
+end

--- a/hydra-core/hydra-core.gemspec
+++ b/hydra-core/hydra-core.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "rails", '~> 4.0'
   gem.add_dependency 'hydra-access-controls', version
   gem.add_dependency 'jettywrapper', '>= 2.0.0'
+  gem.add_dependency 'active-fedora', '~> 9.1'
 
   gem.add_development_dependency 'sqlite3', '~> 1.3'
   gem.add_development_dependency 'yard', '~> 0.8.7'

--- a/hydra-core/lib/generators/hydra/head_generator.rb
+++ b/hydra-core/lib/generators/hydra/head_generator.rb
@@ -76,6 +76,25 @@ module Hydra
       copy_file 'config/blacklight.yml', force: true
     end
 
+    def create_conneg_configuration
+      file_path = "config/initializers/mime_types.rb"
+      inject_into_file file_path, :before => /\Z/  do
+        "\nMime::Type.register \"application/n-triples\", :nt" + 
+        "\nMime::Type.register \"application/json\", :jsonld" +
+        "\nMime::Type.register \"text/turtle\", :ttl"
+      end
+    end
+
+    def inject_solr_document_conneg
+      file_path = "app/models/solr_document.rb"
+      if File.exists?(file_path)
+        inject_into_file file_path, :before => /end\Z/ do
+          "\n  # Do content negotiation for AF models. \n" + 
+          "\n  use_extension( Hydra::ContentNegotiation )\n"
+        end
+      end
+    end
+
     # Add Hydra behaviors to the user model
     def inject_hydra_user_behavior
       file_path = "app/models/#{model_name.underscore}.rb"


### PR DESCRIPTION
Now that Fedora 4 exposes an RDF-Source for each stored asset, it's possible to
expose that metadata through the interface. This provides that as well as a
mechanism to change the URIs that typically come out of Fedora.