### PR TITLE
Explicit route syntax when redirecting to main_app routes

### DIFF
--- a/hydra-core/app/controllers/concerns/hydra/controller/controller_behavior.rb
+++ b/hydra-core/app/controllers/concerns/hydra/controller/controller_behavior.rb
@@ -25,12 +25,12 @@ module Hydra::Controller::ControllerBehavior
   # Override this method if you wish to customize the way access is denied
   def deny_access(exception)
     if exception.action == :edit
-      redirect_to({ action: 'show' }, alert: exception.message)
+      redirect_to(main_app.url_for(action: 'show'), alert: exception.message)
     elsif current_user and current_user.persisted?
-      redirect_to root_path, alert: exception.message
+      redirect_to main_app.root_path, alert: exception.message
     else
       session['user_return_to'.freeze] = request.url
-      redirect_to new_user_session_path, alert: exception.message
+      redirect_to main_app.new_user_session_path, alert: exception.message
     end
   end
 


### PR DESCRIPTION
Modifies Hydra::ControllerBehavior to use more explicit syntax when redirecting a user.  This makes things more consistent when other engines rely on that behavior.

Without this, tests like this one in the curation_concerns gem will break because the code does not know how to find the desired route: https://github.com/pulibrary/hydra-curation_concerns/blob/rename_to_cc/spec/controllers/curation_concerns/generic_works_controller_spec.rb#L75-L78

Sorry I haven't had time to write a test for hydra-head to cover this.  I don't fully understand why this was breaking in curation_concerns, but the change in hydra-head only makes the code more explicit about what's happening, so I'm hoping you'll accept it :smile_cat: 