### PR TITLE
Fix permissions when setting visibility to public from authenticated.

### DIFF
--- a/hydra-access-controls/app/models/concerns/hydra/access_controls/visibility.rb
+++ b/hydra-access-controls/app/models/concerns/hydra/access_controls/visibility.rb
@@ -39,7 +39,7 @@ module Hydra
 
       def public_visibility!
         visibility_will_change! unless visibility == Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
-        set_read_groups([Hydra::AccessControls::AccessRight::PERMISSION_TEXT_VALUE_PUBLIC], [])
+        set_read_groups([Hydra::AccessControls::AccessRight::PERMISSION_TEXT_VALUE_PUBLIC], [Hydra::AccessControls::AccessRight::PERMISSION_TEXT_VALUE_AUTHENTICATED])
       end
 
       def registered_visibility!

--- a/hydra-access-controls/spec/unit/visibility_spec.rb
+++ b/hydra-access-controls/spec/unit/visibility_spec.rb
@@ -11,6 +11,68 @@ describe Hydra::AccessControls::Visibility do
     include VisibilityOverride
   end
 
+  describe "setting visibility" do
+    before {
+      class Foo < ActiveFedora::Base
+        include Hydra::AccessControls::Permissions
+      end
+    }
+    after {
+      Object.send(:remove_const, :Foo)
+    }
+
+    subject { Foo.new }
+
+    [ Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE,
+      Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED,
+      Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC ]
+    .each do |vis|
+
+      describe "to #{vis}" do
+
+        before { subject.visibility=vis }
+
+        it "should be set to #{vis}" do
+          expect(subject.visibility).to eql vis
+        end
+
+        describe "and then to private" do
+          before { subject.visibility=Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE }
+          it "should be set to private" do
+            expect(subject.visibility).to eql Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE
+          end
+          it "should have no permissions" do
+            expect(subject.permissions.map(&:to_hash)).to be_empty
+          end
+        end
+
+        describe "and then to authenticated" do
+          before { subject.visibility=Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED }
+          it "should be set to authenticated" do
+            expect(subject.visibility).to eql Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED
+          end
+          it "should have authenticated permissions only" do
+            expect(subject.permissions.map(&:to_hash)).to match_array [
+                {type: "group", access: "read", name: Hydra::AccessControls::AccessRight::PERMISSION_TEXT_VALUE_AUTHENTICATED } ]
+          end
+        end
+
+        describe "and then to public" do
+          before { subject.visibility=Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC }
+          it "should be set to public" do
+            expect(subject.visibility).to eql Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
+          end
+          it "should have public permissions only" do
+            expect(subject.permissions.map(&:to_hash)).to match_array [
+                {type: "group", access: "read", name: Hydra::AccessControls::AccessRight::PERMISSION_TEXT_VALUE_PUBLIC } ]
+          end
+        end
+      end
+
+    end
+
+  end
+
   it 'allows for overrides of visibility' do
     expect{
       MockParent.new(visibility: Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE)


### PR DESCRIPTION
Going from authenticated visibility to public visibility used to leave the authenticated permission objects behind and add the public one as well. This wasn't a problem with authentication since public is more permissive than authenticated anyway. But some UI code would get confused and think the document visibility is both public and authenticated. Sufia in particular would check the authenticated check box in the permissions edit form instead of public, which was clearly wrong.