### PR TITLE
Append MIME types in the install generator. Fixes projecthydra-labs/hydra-pcdm#132

### DIFF
--- a/hydra-core/lib/generators/hydra/head_generator.rb
+++ b/hydra-core/lib/generators/hydra/head_generator.rb
@@ -78,10 +78,10 @@ module Hydra
 
     def create_conneg_configuration
       file_path = "config/initializers/mime_types.rb"
-      inject_into_file file_path, :before => /\Z/  do
-        "\nMime::Type.register \"application/n-triples\", :nt" + 
-        "\nMime::Type.register \"application/json\", :jsonld" +
-        "\nMime::Type.register \"text/turtle\", :ttl"
+      append_to_file file_path do
+        "Mime::Type.register \"application/n-triples\", :nt\n" + 
+        "Mime::Type.register \"application/json\", :jsonld\n" +
+        "Mime::Type.register \"text/turtle\", :ttl"
       end
     end
 


### PR DESCRIPTION
The install generator currently injects MIME types before every newline, which results in multiple MIME type registrations and lots of warnings in the console.  This PR eliminates all the warnings and results in a tidier . Thanks to @jcoyne for the sleuthery on this one.

Fixes projecthydra-labs/hydra-pcdm#132