### PR TITLE
Adding in the Content-Length header

### DIFF
--- a/hydra-core/app/controllers/concerns/hydra/controller/download_behavior.rb
+++ b/hydra-core/app/controllers/concerns/hydra/controller/download_behavior.rb
@@ -6,7 +6,6 @@ module Hydra
 
       included do
         include Hydra::Controller::ControllerBehavior
-        include ActionController::Live
         before_filter :authorize_download!
       end
 
@@ -136,6 +135,9 @@ module Hydra
       def prepare_file_headers
         send_file_headers! content_options
         response.headers['Content-Type'] = file.mime_type
+        response.headers['Content-Length'] ||= file.size
+        # Prevent Rack::ETag from calculating a digest over body
+        response.headers['Last-Modified'] = asset.modified_date.utc.strftime("%a, %d %b %Y %T GMT")
         self.content_type = file.mime_type
       end
 

--- a/hydra-core/spec/controllers/downloads_controller_spec.rb
+++ b/hydra-core/spec/controllers/downloads_controller_spec.rb
@@ -138,8 +138,7 @@ describe DownloadsController do
         it "head request" do
           request.env["HTTP_RANGE"] = 'bytes=0-15'
           head :show, id: parent, file: 'webm'
-          # See https://github.com/rails/rails/issues/18714
-          # expect(response.headers['Content-Length']).to eq 16
+          expect(response.headers['Content-Length']).to eq 16
           expect(response.headers['Accept-Ranges']).to eq 'bytes'
           expect(response.headers['Content-Type']).to eq 'video/webm'
         end
@@ -148,8 +147,7 @@ describe DownloadsController do
           get :show, id: '1234', file: 'webm'
           expect(response.body).to eq 'one1two2threfour'
           expect(response.headers["Content-Range"]).to eq 'bytes 0-15/16'
-          # See https://github.com/rails/rails/issues/18714
-          # expect(response.headers["Content-Length"]).to eq '16'
+          expect(response.headers["Content-Length"]).to eq '16'
           expect(response.headers['Accept-Ranges']).to eq 'bytes'
           expect(response.headers['Content-Type']).to eq "video/webm"
           expect(response.headers["Content-Disposition"]).to eq "inline; filename=\"MyVideo.webm\""
@@ -165,16 +163,14 @@ describe DownloadsController do
           get :show, id: '1234', file: 'webm'
           expect(response.body).to eq '1two2threfour'
           expect(response.headers["Content-Range"]).to eq 'bytes 3-15/16'
-          # See https://github.com/rails/rails/issues/18714
-          # expect(response.headers["Content-Length"]).to eq '13'
+          expect(response.headers["Content-Length"]).to eq '13'
         end
         it "should get a range not ending at the end" do
           request.env["HTTP_RANGE"] = 'bytes=4-11'
           get :show, id: '1234', file: 'webm'
           expect(response.body).to eq 'two2thre'
           expect(response.headers["Content-Range"]).to eq 'bytes 4-11/16'
-          # See https://github.com/rails/rails/issues/18714
-          # expect(response.headers["Content-Length"]).to eq '8'
+          expect(response.headers["Content-Length"]).to eq '8'
         end
       end
     end


### PR DESCRIPTION
We are having issues with downloading files larger than 300MB.  Sometimes the browser downloads the entire thing, other time it does not.  Adding the length back in gives us consistent download behavior.

@jcoyne does this undo your streaming change?  I looked at the comments on your bug to find the cache solution, but I am not 100% sure I did not foul things up...