### PR TITLE
Role mapper should fetch keys

### DIFF
--- a/hydra-access-controls/lib/hydra/role_mapper_behavior.rb
+++ b/hydra-access-controls/lib/hydra/role_mapper_behavior.rb
@@ -5,23 +5,23 @@ module Hydra::RoleMapperBehavior
     def role_names
       map.keys
     end
-    
-    # 
+
+    ##
     # @param user_or_uid either the User object or user id
     # If you pass in a nil User object (ie. user isn't logged in), or a uid that doesn't exist, it will return an empty array
     def roles(user_or_uid)
       if user_or_uid.kind_of?(String)
         user = Hydra::Ability.user_class.find_by_user_key(user_or_uid)
         user_id = user_or_uid
-      elsif user_or_uid.kind_of?(Hydra::Ability.user_class) && user_or_uid.user_key   
+      elsif user_or_uid.kind_of?(Hydra::Ability.user_class) && user_or_uid.user_key
         user = user_or_uid
         user_id = user.user_key
       end
       array = byname[user_id].dup || []
-      array = array << 'registered' unless (user.nil? || user.new_record?) 
+      array = array << 'registered' unless (user.nil? || user.new_record?)
       array
     end
-    
+
     def whois(r)
       map[r] || []
     end
@@ -32,7 +32,7 @@ module Hydra::RoleMapperBehavior
 
 
     def byname
-      @byname ||= map.each_with_object(Hash.new{ |h,k| h[k] = [] }) do |(role, usernames), memo| 
+      @byname ||= map.each_with_object(Hash.new{ |h,k| h[k] = [] }) do |(role, usernames), memo|
         Array(usernames).each { |x| memo[x] << role}
       end
     end
@@ -60,9 +60,12 @@ module Hydra::RoleMapperBehavior
         rescue
           raise("#{filename} was found, but could not be parsed.\n")
         end
-        return yml[Rails.env] if yml.is_a? Hash
+        unless yml.is_a? Hash
+          raise("#{filename} was found, but was blank or malformed.\n")
+        end
 
-        raise("#{filename} was found, but was blank or malformed.\n")
+        yml.fetch(Rails.env)
+
       end
   end
 end

--- a/hydra-access-controls/spec/unit/role_mapper_spec.rb
+++ b/hydra-access-controls/spec/unit/role_mapper_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe RoleMapper do
   it "should define the 4 roles" do
-    expect(RoleMapper.role_names.sort).to eq %w(admin_policy_object_editor archivist donor patron researcher) 
+    expect(RoleMapper.role_names.sort).to eq %w(admin_policy_object_editor archivist donor patron researcher)
   end
   it "should quer[iy]able for roles for a given user" do
     expect(RoleMapper.roles('leland_himself@example.com').sort).to eq ['archivist', 'donor', 'patron']


### PR DESCRIPTION
This raises an error when the environment isn't found instead of a Nil
pointer error like:

```
NoMethodError (undefined method `each_with_object' for nil:NilClass):
  hydra-access-controls (9.2.2) lib/hydra/role_mapper_behavior.rb:35:in
  `byname'
    hydra-access-controls (9.2.2) lib/hydra/role_mapper_behavior.rb:20:in `roles'
    hydra-access-controls (9.2.2) lib/hydra/user.rb:18:in `groups'
```