### PR TITLE
Provide CanCan abilities for discover permissions

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -23,6 +23,7 @@ Contributors to this project:
 *  Michael J. Giarlo
 *  Monty Hindman
 *  Naomi Dushay
+*  Randy Coulman
 *  Richard Johnson
 *  Spoken Word Administrator
 *  cam156

--- a/HISTORY.textile
+++ b/HISTORY.textile
@@ -1,3 +1,6 @@
+h3. Unreleased
+* 2015-10-03: Provide CanCan abilities for :discover permissions. [Randy Coulman]
+
 h3. 9.2.2 (2015-08-03)
 * 2015-07-30: Moved condition logic to its own method to give app developer a chance to configure it to not perform future date validation [val99erie]
 

--- a/hydra-access-controls/README.textile
+++ b/hydra-access-controls/README.textile
@@ -23,7 +23,7 @@ The hydra generator handles part of this for you - it sets up the CatalogControl
 Beyond enabling gated discovery, *everything is done using "CanCan":https://github.com/ryanb/cancan*.  For more information on CanCan, how to use it, and how to define access controls policies (aka "abilities":https://github.com/ryanb/cancan/wiki/Defining-Abilities), refer to the "CanCan documentation":https://github.com/ryanb/cancan/blob/master/README.rdoc.
 
 Within your CanCan ability definitions, app/models/ability.rb, the "Hydra::Ability":https://github.com/projecthydra/hydra-head/blob/master/hydra-access-controls/lib/hydra/ability.rb module is already included. This module has
-:read and :edit permissions defined for you, along with some convenience methods that help you evaluate permssions
+:read, :edit, and :discover permissions defined for you, along with some convenience methods that help you evaluate permssions
 against info in the rightsMetadata datastream.
 
 In your custom controllers, you will need to enforce access controls using "CanCan":https://github.com/ryanb/cancan.  There are a number of ways to do this.  The easiest way is to use the cancan "controller action":https://github.com/ryanb/cancan/wiki/Authorizing-Controller-Actions 'load_and_authorize_resource', however on show and edit, this also causes a load the resource from fedora, which you may want to avoid.  If you want to authorize from solr, you ought to be able to call the cancan methods `authorize!` or `can?` which just checks the solr permissions handler. 

--- a/hydra-access-controls/spec/unit/ability_spec.rb
+++ b/hydra-access-controls/spec/unit/ability_spec.rb
@@ -8,6 +8,8 @@ describe Ability do
     its(:read_user_field) { should == 'read_access_person_ssim'}
     its(:edit_group_field) { should == 'edit_access_group_ssim'}
     its(:edit_user_field) { should == 'edit_access_person_ssim'}
+    its(:discover_group_field) { should == 'discover_access_group_ssim'}
+    its(:discover_user_field) { should == 'discover_access_person_ssim'}
   end
 
   context "for a not-signed in user" do
@@ -37,6 +39,35 @@ describe Ability do
 #   See spec/requests/... for test coverage describing WHAT should appear on a page based on access permissions
 #   Test coverage for discover permission is in spec/requests/gated_discovery_spec.rb
 
+  describe "Given an asset that has been made publicly discoverable" do
+    let(:asset) { FactoryGirl.create(:asset) }
+    before do
+      asset.permissions_attributes = [{ name: "public", access: "discover", type: "group" }, { name: "joe_creator", access: "edit", type: "person" }, { name: "calvin_collaborator", access: "edit", type: "person" }]
+      asset.save
+    end
+
+    context "Then a not-signed-in user" do
+      subject { Ability.new(nil) }
+      it { should     be_able_to(:discover, asset) }
+      it { should_not be_able_to(:read, asset) }
+      it { should_not be_able_to(:edit, asset) }
+      it { should_not be_able_to(:update, asset) }
+      it { should_not be_able_to(:destroy, asset) }
+    end
+
+    context "Then a registered user" do
+      before do
+        @user = FactoryGirl.build(:registered_user)
+      end
+      subject { Ability.new(@user) }
+      it { should     be_able_to(:discover, asset) }
+      it { should_not be_able_to(:read, asset) }
+      it { should_not be_able_to(:edit, asset) }
+      it { should_not be_able_to(:update, asset) }
+      it { should_not be_able_to(:destroy, asset) }
+    end
+  end
+
   describe "Given an asset that has been made publicly available (ie. open access)" do
     #let(:asset) { FactoryGirl.create(:open_access_asset) }
     let(:asset) { FactoryGirl.create(:asset) }
@@ -47,6 +78,7 @@ describe Ability do
 
     context "Then a not-signed-in user" do
       subject { Ability.new(nil) }
+      it { should     be_able_to(:discover, asset) }
       it { should     be_able_to(:read, asset) }
       it { should_not be_able_to(:edit, asset) }
       it { should_not be_able_to(:update, asset) }
@@ -58,6 +90,7 @@ describe Ability do
         @user = FactoryGirl.build(:registered_user)
       end
       subject { Ability.new(@user) }
+      it { should     be_able_to(:discover, asset) }
       it { should     be_able_to(:read, asset) }
       it { should_not be_able_to(:edit, asset) }
       it { should_not be_able_to(:update, asset) }
@@ -76,6 +109,7 @@ describe Ability do
     context "Then a not-signed-in user" do
       let(:user) { User.new.tap {|u| u.new_record = true } }
       subject { Ability.new(user) }
+      it { should_not be_able_to(:discover, asset) }
       it { should_not be_able_to(:read, asset) }
       it { should_not be_able_to(:edit, asset) }
       it { should_not be_able_to(:update, asset) }
@@ -83,6 +117,7 @@ describe Ability do
     end
     context "Then a registered user" do
       subject { Ability.new(FactoryGirl.build(:registered_user)) }
+      it { should_not be_able_to(:discover, asset) }
       it { should_not be_able_to(:read, asset) }
       it { should_not be_able_to(:edit, asset) }
       it { should_not be_able_to(:update, asset) }
@@ -90,6 +125,7 @@ describe Ability do
     end
     context "Then the Creator" do
       subject { Ability.new(FactoryGirl.build(:joe_creator)) }
+      it { should     be_able_to(:discover, asset) }
       it { should     be_able_to(:read, asset) }
       it { should     be_able_to(:edit, asset) }
       it { should     be_able_to(:edit, solr_doc) }
@@ -114,6 +150,7 @@ describe Ability do
       end
       subject { Ability.new(@user) }
 
+      it { should     be_able_to(:discover, asset) }
       it { should     be_able_to(:read, asset) }
       it { should_not be_able_to(:edit, asset) }
       it { should_not be_able_to(:update, asset) }
@@ -136,6 +173,7 @@ describe Ability do
       end
       subject { Ability.new(@user) }
 
+      it { should     be_able_to(:discover, asset) }
       it { should     be_able_to(:read, asset) }
       it { should     be_able_to(:edit, asset) }
       it { should     be_able_to(:update, asset) }
@@ -167,6 +205,7 @@ describe Ability do
       end
       subject { Ability.new(@user) }
 
+      it { should_not be_able_to(:discover, asset) }
       it { should_not be_able_to(:read, asset) }
       it { should_not be_able_to(:edit, asset) }
       it { should_not be_able_to(:update, asset) }
@@ -181,6 +220,7 @@ describe Ability do
       end
       subject { Ability.new(@user) }
 
+      it { should     be_able_to(:discover, asset) }
       it { should     be_able_to(:read, asset) }
       it { should_not be_able_to(:edit, asset) }
       it { should_not be_able_to(:update, asset) }


### PR DESCRIPTION
hydra-access-controls provides CanCan abilities for `:read`, `:edit`, and `:download` permissions, but not `:discover`.  This change adds abilities for `:discover`.

The implementation parallels that used for `:read` and `:edit` permissions.  It assumes that if a document can be `:read`, then it can also be `:discover`ed, but not vice-versa.

I added/updated unit tests accordingly.  `ability_spec.rb` has a comment that references some request specs, but I couldn’t find those in the codebase so I didn’t add any of those specs.