### PR TITLE
Make content-length a string so webrick will be happy.

### DIFF
--- a/hydra-core/app/controllers/concerns/hydra/controller/download_behavior.rb
+++ b/hydra-core/app/controllers/concerns/hydra/controller/download_behavior.rb
@@ -135,7 +135,7 @@ module Hydra
       def prepare_file_headers
         send_file_headers! content_options
         response.headers['Content-Type'] = file.mime_type
-        response.headers['Content-Length'] ||= file.size
+        response.headers['Content-Length'] ||= file.size.to_s
         # Prevent Rack::ETag from calculating a digest over body
         response.headers['Last-Modified'] = asset.modified_date.utc.strftime("%a, %d %b %Y %T GMT")
         self.content_type = file.mime_type


### PR DESCRIPTION
Resolves bug discussed on list: https://groups.google.com/forum/#!searchin/hydra-tech/sufia$20internal/hydra-tech/UMnWsDxSGdY/KzB70wSMBwAJ

thumbnails fail to load via webrick, example trace: 
[2015-10-14 16:33:08] ERROR NoMethodError: undefined method `split' for 5157:Fixnum
    /home/jhallida/.rvm/gems/ruby-2.1.7@sufia6/gems/rack-1.6.4/lib/rack/handler/webrick.rb:99:in `block in service'
    /home/jhallida/.rvm/gems/ruby-2.1.7@sufia6/gems/rack-1.6.4/lib/rack/utils.rb:490:in `block in each'
    /home/jhallida/.rvm/gems/ruby-2.1.7@sufia6/gems/rack-1.6.4/lib/rack/utils.rb:489:in `each'
    /home/jhallida/.rvm/gems/ruby-2.1.7@sufia6/gems/rack-1.6.4/lib/rack/utils.rb:489:in `each'
    /home/jhallida/.rvm/gems/ruby-2.1.7@sufia6/gems/rack-1.6.4/lib/rack/handler/webrick.rb:91:in `service'
    /home/jhallida/.rvm/rubies/ruby-2.1.7/lib/ruby/2.1.0/webrick/httpserver.rb:138:in `service'
    /home/jhallida/.rvm/rubies/ruby-2.1.7/lib/ruby/2.1.0/webrick/httpserver.rb:94:in `run'
    /home/jhallida/.rvm/rubies/ruby-2.1.7/lib/ruby/2.1.0/webrick/server.rb:295:in `block in start_thread'