### PR TITLE
Extracted some of hydra-access-controls code to a new gem, blacklight-access_controls.

### DIFF
--- a/hydra-access-controls/hydra-access-controls.gemspec
+++ b/hydra-access-controls/hydra-access-controls.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'cancancan', '~> 1.8'
   gem.add_dependency 'deprecation', '~> 0.2'
   gem.add_dependency "blacklight", '~> 5.16'
+  gem.add_dependency "blacklight-access_controls", '0.1.0'
 
   # sass-rails is typically generated into the app's gemfile by `rails new`
   # In rails 3 it's put into the "assets" group and thus not available to the

--- a/hydra-access-controls/lib/hydra-access-controls.rb
+++ b/hydra-access-controls/lib/hydra-access-controls.rb
@@ -3,6 +3,7 @@ require 'active-fedora'
 require 'blacklight'
 require 'cancan'
 require "deprecation"
+require 'blacklight-access_controls'
 
 module Hydra
   extend ActiveSupport::Autoload

--- a/hydra-access-controls/lib/hydra/access_controls_enforcement.rb
+++ b/hydra-access-controls/lib/hydra/access_controls_enforcement.rb
@@ -1,35 +1,8 @@
 module Hydra::AccessControlsEnforcement
   extend ActiveSupport::Concern
-
-  included do |klass|
-    attr_writer :current_ability
-    class_attribute :solr_access_filters_logic
-
-    # Set defaults. Each symbol identifies a _method_ that must be in
-    # this class, taking one parameter (permission_types)
-    # Can be changed in local apps or by plugins, eg:
-    # CatalogController.include ModuleDefiningNewMethod
-    # CatalogController.solr_access_filters_logic += [:new_method]
-    # CatalogController.solr_access_filters_logic.delete(:we_dont_want)
-    self.solr_access_filters_logic = [:apply_group_permissions, :apply_user_permissions]
-
-  end
-
-  def current_ability
-    @current_ability || raise("current_ability has not been set on #{self}")
-  end
+  include Blacklight::AccessControls::Enforcement
 
   protected
-
-  def gated_discovery_filters(permission_types = discovery_permissions, ability = current_ability)
-    user_access_filters = []
-
-    # Grant access based on user id & group
-    solr_access_filters_logic.each do |method_name|
-      user_access_filters += send(method_name, permission_types, ability)
-    end
-    user_access_filters
-  end
 
   def under_embargo?
     load_permissions_from_solr
@@ -41,82 +14,18 @@ module Hydra::AccessControlsEnforcement
     false
   end
 
-  #
-  # Action-specific enforcement
-  #
-
-  # Controller "before" filter for enforcing access controls on show actions
-  # @param [Hash] opts (optional, not currently used)
-  def enforce_show_permissions(opts={})
-    permissions = current_ability.permissions_doc(params[:id])
-    if permissions.under_embargo? && !can?(:edit, permissions)
-      raise Hydra::AccessDenied.new("This item is under embargo.  You do not have sufficient access privileges to read this document.", :edit, params[:id])
-    end
-    unless can? :read, permissions
-      raise Hydra::AccessDenied.new("You do not have sufficient access privileges to read this document, which has been marked private.", :read, params[:id])
-    end
-  end
-
-  # Solr query modifications
-  #
-
-  # Set solr_parameters to enforce appropriate permissions
-  # * Applies a lucene query to the solr :q parameter for gated discovery
-  # * Uses public_qt search handler if user does not have "read" permissions
-  # @param solr_parameters the current solr parameters
-  #
-  # @example This method should be added to your CatalogController's search_params_logic
-  #   class CatalogController < ApplicationController
-  #     CatalogController.search_params_logic += [:add_access_controls_to_solr_params]
-  #   end
-  def add_access_controls_to_solr_params(solr_parameters)
-    apply_gated_discovery(solr_parameters)
-  end
-
-
   # Which permission levels (logical OR) will grant you the ability to discover documents in a search.
-
-  # Override this method if you want it to be something other than the default
+  # Overrides blacklight-access_controls method.
   def discovery_permissions
     @discovery_permissions ||= ["edit","discover","read"]
   end
-  def discovery_permissions= (permissions)
-    @discovery_permissions = permissions
+
+  # Find the name of the solr field for this type of permission.
+  # e.g. "read_access_group_ssim" or "discover_access_person_ssim".
+  # Used by blacklight-access_controls.
+  def solr_field_for(permission_type, permission_category)
+    permissions = Hydra.config.permissions[permission_type.to_sym]
+    permission_category == 'group' ? permissions.group : permissions.individual
   end
 
-  # Contrller before filter that sets up access-controlled lucene query in order to provide gated discovery behavior
-  # @param solr_parameters the current solr parameters
-  def apply_gated_discovery(solr_parameters)
-    solr_parameters[:fq] ||= []
-    solr_parameters[:fq] << gated_discovery_filters.join(" OR ")
-    Rails.logger.debug("Solr parameters: #{ solr_parameters.inspect }")
-  end
-
-
-  def apply_group_permissions(permission_types, ability = current_ability)
-      # for groups
-      user_access_filters = []
-      ability.user_groups.each_with_index do |group, i|
-        permission_types.each do |type|
-          user_access_filters << escape_filter(Hydra.config.permissions[type.to_sym].group, group)
-        end
-      end
-      user_access_filters
-  end
-
-  def escape_filter(key, value)
-    [key, value.gsub(/[ :\/]/, ' ' => '\ ', '/' => '\/', ':' => '\:')].join(':')
-  end
-
-  def apply_user_permissions(permission_types, ability = current_ability)
-      # for individual user access
-      user_access_filters = []
-      user = ability.current_user
-      if user && user.user_key.present?
-        permission_types.each do |type|
-          user_access_filters << escape_filter(Hydra.config.permissions[type.to_sym].individual, user.user_key)
-        end
-      end
-      user_access_filters
-  end
 end

--- a/hydra-access-controls/lib/hydra/permissions_cache.rb
+++ b/hydra-access-controls/lib/hydra/permissions_cache.rb
@@ -1,18 +1,6 @@
-class Hydra::PermissionsCache
-  def initialize
-    clear 
-  end
+class Hydra::PermissionsCache < Blacklight::AccessControls::PermissionsCache
+  extend Deprecation
 
-  def get(pid)
-    @cache[pid]
-  end
-
-  def put(pid, doc)
-    @cache[pid] = doc 
-  end
-
-  def clear
-    @cache = {}
-  end
+  Deprecation.warn Hydra::PermissionsCache, "Hydra::PermissionsCache will be removed in Hydra 10.  Use Blacklight::AccessControls::PermissionsCache instead (from blacklight-access_controls gem)."
 
 end

--- a/hydra-access-controls/lib/hydra/permissions_query.rb
+++ b/hydra-access-controls/lib/hydra/permissions_query.rb
@@ -2,48 +2,13 @@ module Hydra
   module PermissionsQuery
     extend ActiveSupport::Concern
 
-    def permissions_doc(pid)
-      doc = cache.get(pid)
-      unless doc
-        doc = get_permissions_solr_response_for_doc_id(pid)
-        cache.put(pid, doc)
-      end
-      doc
+    include Blacklight::AccessControls::PermissionsQuery
+
+    # What type of solr document to create for the
+    # Blacklight::AccessControls::PermissionsQuery.
+    def permissions_document_class
+      Hydra::PermissionsSolrDocument
     end
 
-    protected
-
-    # a solr query method
-    # retrieve a solr document, given the doc id
-    # Modeled on Blacklight::SolrHelper.get_permissions_solr_response_for_doc_id
-    # @param [String] id of the documetn to retrieve
-    # @param [Hash] extra_controller_params (optional)
-    def get_permissions_solr_response_for_doc_id(id=nil, extra_controller_params={})
-      raise Blacklight::Exceptions::InvalidSolrID.new("The application is trying to retrieve permissions without specifying an asset id") if id.nil?
-      solr_opts = permissions_solr_doc_params(id).merge(extra_controller_params)
-      response = ActiveFedora::SolrService.instance.conn.get('select', params: solr_opts)
-      solr_response = Blacklight::Solr::Response.new(response, solr_opts)
-
-      raise Blacklight::Exceptions::InvalidSolrID.new("The solr permissions search handler didn't return anything for id \"#{id}\"") if solr_response.docs.empty?
-      Hydra::PermissionsSolrDocument.new(solr_response.docs.first, solr_response)
-    end
-
-    #
-    #  Solr integration
-    #
-
-    # returns a params hash with the permissions info for a single solr document
-    # If the id arg is nil, then the value is fetched from params[:id]
-    # This method is primary called by the get_permissions_solr_response_for_doc_id method.
-    # Modeled on Blacklight::SolrHelper.solr_doc_params
-    # @param [String] id of the documetn to retrieve
-    def permissions_solr_doc_params(id=nil)
-      id ||= params[:id]
-      # just to be consistent with the other solr param methods:
-      {
-        qt: :permissions,
-        id: id # this assumes the document request handler will map the 'id' param to the unique key field
-      }
-    end
   end
 end

--- a/hydra-access-controls/lib/hydra/policy_aware_ability.rb
+++ b/hydra-access-controls/lib/hydra/policy_aware_ability.rb
@@ -1,6 +1,7 @@
 # Repeats access controls evaluation methods, but checks against a governing "Policy" object (or "Collection" object) that provides inherited access controls.
 module Hydra::PolicyAwareAbility
   extend ActiveSupport::Concern
+  include Blacklight::AccessControls::Ability
   include Hydra::Ability
 
   IS_GOVERNED_BY_SOLR_FIELD = "isGovernedBy_ssim".freeze

--- a/hydra-access-controls/lib/hydra/policy_aware_access_controls_enforcement.rb
+++ b/hydra-access-controls/lib/hydra/policy_aware_access_controls_enforcement.rb
@@ -6,8 +6,7 @@ module Hydra::PolicyAwareAccessControlsEnforcement
   # @param solr_parameters the current solr parameters
   # @param user_parameters the current user-subitted parameters
   def apply_gated_discovery(solr_parameters)
-    solr_parameters[:fq] ||= []
-    solr_parameters[:fq] << gated_discovery_filters.join(' OR '.freeze)
+    super
     logger.debug("POLICY-aware Solr parameters: #{ solr_parameters.inspect }")
   end
 
@@ -50,6 +49,11 @@ module Hydra::PolicyAwareAccessControlsEnforcement
     end
   end
 
+  # Override method from blacklight-access_controls
+  def discovery_permissions
+    @discovery_permissions ||= ["edit", "discover", "read"]
+  end
+
   # Returns the Model used for AdminPolicy objects.
   # You can set this by overriding this method or setting Hydra.config[:permissions][:policy_class]
   # Defults to Hydra::AdminPolicy
@@ -66,6 +70,14 @@ module Hydra::PolicyAwareAccessControlsEnforcement
       filters << additional_clauses
     end
     filters
+  end
+
+  # Find the name of the solr field for this type of permission.
+  # e.g. "read_access_group_ssim" or "discover_access_person_ssim".
+  # Used by blacklight-access_controls gem.
+  def solr_field_for(permission_type, permission_category)
+    permissions = Hydra.config.permissions[permission_type.to_sym]
+    permission_category == 'group' ? permissions.group : permissions.individual
   end
 
 end

--- a/hydra-access-controls/lib/hydra/user.rb
+++ b/hydra-access-controls/lib/hydra/user.rb
@@ -2,16 +2,11 @@
 # By default, this module assumes you are using the User model created by Blacklight, which uses Devise.
 # To integrate your own User implementation into Hydra, override this Module or define your own User model in app/models/user.rb within your Hydra head.
 module Hydra::User
+  include Blacklight::AccessControls::User
   
   def self.included(klass)
     # Other modules to auto-include
     klass.extend(ClassMethods)
-  end
-
-  # This method should display the unique identifier for this user as defined by devise.
-  # The unique identifier is what access controls will be enforced against. 
-  def user_key
-    send(Devise.authentication_keys.first)
   end
 
   def groups

--- a/hydra-access-controls/spec/unit/ability_spec.rb
+++ b/hydra-access-controls/spec/unit/ability_spec.rb
@@ -233,6 +233,7 @@ describe Ability do
   describe "custom method" do
     before do
       class MyAbility
+        include Blacklight::AccessControls::Ability
         include Hydra::Ability
         self.ability_logic +=[:setup_my_permissions]
 

--- a/hydra-access-controls/spec/unit/policy_aware_access_controls_enforcement_spec.rb
+++ b/hydra-access-controls/spec/unit/policy_aware_access_controls_enforcement_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe Hydra::PolicyAwareAccessControlsEnforcement do
   before do
-    class PolicyMockSearchBuilder
+    class PolicyMockSearchBuilder < Blacklight::Solr::SearchBuilder
       include Hydra::AccessControlsEnforcement
       include Hydra::PolicyAwareAccessControlsEnforcement
       attr_accessor :params
@@ -100,12 +100,14 @@ describe Hydra::PolicyAwareAccessControlsEnforcement do
       before do
         allow(RoleMapper).to receive(:roles).with(user).and_return(user.roles)
       end
+
       it "should return the policies that provide discover permissions" do
         @policies_with_access.map {|p| p.id }.each do |p|
           expect(subject.policies_with_access).to include(p)
         end
         expect(subject.policies_with_access).to_not include("test-policy_no_access")
       end
+
       it "should allow you to configure which model to use for policies" do
         allow(Hydra.config.permissions).to receive(:policy_class).and_return(ModsAsset)
         expect(ModsAsset).to receive(:find_with_conditions).and_return([])

--- a/hydra-core/app/controllers/concerns/hydra/catalog.rb
+++ b/hydra-core/app/controllers/concerns/hydra/catalog.rb
@@ -1,5 +1,23 @@
 module Hydra::Catalog
   extend ActiveSupport::Concern
   include Blacklight::Catalog
-  include Hydra::Controller::SearchBuilder
+  include Blacklight::AccessControls::Catalog
+
+  # Action-specific enforcement
+  # Controller "before" filter for enforcing access controls on show actions
+  # @param [Hash] opts (optional, not currently used)
+  def enforce_show_permissions(opts={})
+    # The "super" method comes from blacklight-access_controls.
+    # It will check the read permissions for the record.
+    # By default, it will return a Hydra::PermissionsSolrDocument
+    # that contains the permissions fields for that record
+    # so that you can perform additional permissions checks.
+    permissions_doc = super
+
+    if permissions_doc.under_embargo? && !can?(:edit, permissions_doc)
+      raise Hydra::AccessDenied.new("This item is under embargo.  You do not have sufficient access privileges to read this document.", :edit, params[:id])
+    end
+
+    permissions_doc
+  end
 end

--- a/hydra-core/app/controllers/concerns/hydra/controller/search_builder.rb
+++ b/hydra-core/app/controllers/concerns/hydra/controller/search_builder.rb
@@ -1,9 +1,8 @@
 module Hydra::Controller::SearchBuilder
   extend ActiveSupport::Concern
 
-  # Override blacklight to produce a search_builder that has the current ability in context
-  def search_builder processor_chain = search_params_logic
-    super.tap { |builder| builder.current_ability = current_ability }
+  included do
+    Deprecation.warn Hydra::Controller::SearchBuilder, "Hydra::Controller::SearchBuilder no longer does anything.  It will be removed in Hydra version 10.  The code that used to be in this module was moved to Blacklight::AccessControls::Catalog in the blacklight-access_controls gem."
   end
 
 end

--- a/hydra-core/lib/generators/hydra/templates/catalog_controller.rb
+++ b/hydra-core/lib/generators/hydra/templates/catalog_controller.rb
@@ -6,6 +6,7 @@ class CatalogController < ApplicationController
   include Hydra::Catalog
   # These before_filters apply the hydra access controls
   before_filter :enforce_show_permissions, :only=>:show
+
   # This applies appropriate access controls to all solr queries
   CatalogController.search_params_logic += [:add_access_controls_to_solr_params]
 

--- a/hydra-core/spec/controllers/downloads_controller_spec.rb
+++ b/hydra-core/spec/controllers/downloads_controller_spec.rb
@@ -39,6 +39,7 @@ describe DownloadsController do
     end
 
     context "when not logged in" do
+
       context "when a specific datastream is requested" do
         it "should redirect to the root path and display an error" do
           get :show, id: obj, file: "descMetadata"
@@ -47,6 +48,7 @@ describe DownloadsController do
         end
       end
     end
+
     context "when logged in, but without read access" do
       let(:user) { User.create(email: 'email2@example.com', password: 'password') }
       before do


### PR DESCRIPTION
I ported the "read" & "discover" parts of hydra-access-controls into a new gem, blacklight-access_controls, so that blacklight apps can use access controls too.  The new gem is here:
https://github.com/projectblacklight/blacklight-access_controls

I removed the ported code from hydra-head, and made hydra-head depend on blacklight-access_controls so that we won't have duplicate/divergent code.

Ping @jcoyne and @cam156 for code review.