### PR TITLE
Use the template to set the model name

### DIFF
--- a/hydra-core/lib/generators/hydra/head_generator.rb
+++ b/hydra-core/lib/generators/hydra/head_generator.rb
@@ -6,7 +6,7 @@ module Hydra
 
     source_root File.expand_path('../templates', __FILE__)
 
-    argument :model_name, :type => :string , :default => "user"
+    argument :model_name, type: :string , default: 'User'
     class_option :'skip-rspec', type: :boolean, default: false, desc: "Skip the rspec generator"
 
 
@@ -55,13 +55,8 @@ module Hydra
     def create_configuration_files
 
       # Initializers
-      file_path = "config/initializers/hydra_config.rb"
-      copy_file "config/initializers/hydra_config.rb", file_path
-      unless model_name == 'user'
-        insert_into_file file_path, :after => 'Hydra.configure do |config|' do
-            "\n  config.user_model = '#{model_name.classify}'"
-        end
-      end
+      template "config/initializers/hydra_config.rb",
+               "config/initializers/hydra_config.rb"
 
       # Role Mappings
       copy_file "config/role_map.yml", "config/role_map.yml"

--- a/hydra-core/lib/generators/hydra/templates/config/initializers/hydra_config.rb
+++ b/hydra-core/lib/generators/hydra/templates/config/initializers/hydra_config.rb
@@ -17,6 +17,6 @@ Hydra.configure do |config|
   # config.permissions.lease.expiration_date = ActiveFedora::SolrQueryBuilder.solr_name("lease_expiration_date", :stored_sortable, type: :date)
   #
   #
-  # specify the user model
-  # config.user_model = '#{model_name.classify}'
+  # Specify the user model
+  <%= '# ' if model_name == 'User' %>config.user_model = '<%= model_name %>'
 end


### PR DESCRIPTION
Previously if you didn't specify the model name this line would have
been generated into the config:

  # config.user_model = '#{model_name.classify}'

Now it's:

  # config.user_model = 'User'