### PR TITLE
Call id_to_resource_uri with a graph

### DIFF
--- a/hydra-access-controls/lib/hydra/config.rb
+++ b/hydra-access-controls/lib/hydra/config.rb
@@ -41,7 +41,7 @@ module Hydra
     #
     # @return [Lambda] a method to convert ID to a URI
     def id_to_resource_uri
-      @id_to_resource_uri ||= ActiveFedora::Base.translate_id_to_uri
+      @id_to_resource_uri ||= lambda { |id, _graph| ActiveFedora::Base.translate_id_to_uri.call(id) }
     end
 
     def permissions= values

--- a/hydra-core/app/models/hydra/content_negotiation/fedora_uri_replacer.rb
+++ b/hydra-core/app/models/hydra/content_negotiation/fedora_uri_replacer.rb
@@ -16,7 +16,7 @@ module Hydra::ContentNegotiation
 
     def replace_uri(uri)
       id = ActiveFedora::Base.uri_to_id(uri)
-      RDF::URI(Hydra.config.id_to_resource_uri.call(id))
+      RDF::URI(Hydra.config.id_to_resource_uri.call(id, graph))
     end
 
     def replaced_objects

--- a/hydra-core/spec/controllers/catalog_controller_spec.rb
+++ b/hydra-core/spec/controllers/catalog_controller_spec.rb
@@ -91,7 +91,7 @@ describe CatalogController do
         end
         context "with a configured subject converter" do
           before do
-            Hydra.config.id_to_resource_uri = lambda { |id| "http://hydra.box/catalog/#{id}" }
+            Hydra.config.id_to_resource_uri = lambda { |id, _| "http://hydra.box/catalog/#{id}" }
             get 'show', :id => asset.id, :format => :nt
           end
           it "should convert it" do


### PR DESCRIPTION
Because the generated uri may depend on other triples in the graph such
as fedora:hasModel