### PR TITLE
Update `rake hydra:server` to listen on all ports

### DIFF
--- a/hydra-core/lib/tasks/hydra.rake
+++ b/hydra-core/lib/tasks/hydra.rake
@@ -6,7 +6,7 @@ namespace :hydra do
     with_server('development',
                 fcrepo_port: ENV.fetch('FCREPO_PORT', '8984'),
                 solr_port: ENV.fetch('SOLR_PORT', '8983')) do
-      `rails server`
+      `rails server -b 0.0.0.0`
     end
   end
 end


### PR DESCRIPTION
Required when running `rails server` in a VM with port 3000 forwarded to host.