### PR TITLE
Make rake hydra:server VM friendly

### DIFF
--- a/hydra-core/lib/tasks/hydra.rake
+++ b/hydra-core/lib/tasks/hydra.rake
@@ -3,10 +3,12 @@ require 'active_fedora/rake_support'
 namespace :hydra do
   desc "Start a solr, fedora and rails instance"
   task :server do
+    rails_interface = ENV.fetch('RAILS_INTERFACE', '127.0.0.1')
+    rails_port = ENV.fetch('RAILS_PORT', '3000')
     with_server('development',
                 fcrepo_port: ENV.fetch('FCREPO_PORT', '8984'),
                 solr_port: ENV.fetch('SOLR_PORT', '8983')) do
-      IO.popen('rails server') do |io|
+      IO.popen("rails server -b #{rails_interface} -p #{rails_port}") do |io|
         begin
           io.each do |line|
             puts line


### PR DESCRIPTION
When running on a VM, we need webbrick to listen on all interfaces to respond to port forwarding.  The default is to just listen on the internal loopback, which can't be reached from outside the VM using port forwarding.