### PR TITLE
Don't explicitly add access controls

### DIFF
--- a/hydra-core/lib/generators/hydra/templates/catalog_controller.rb
+++ b/hydra-core/lib/generators/hydra/templates/catalog_controller.rb
@@ -7,10 +7,6 @@ class CatalogController < ApplicationController
   # These before_filters apply the hydra access controls
   before_filter :enforce_show_permissions, only: :show
 
-  # This applies appropriate access controls to all solr queries
-  Hydra::SearchBuilder.default_processor_chain += [:add_access_controls_to_solr_params]
-
-
   configure_blacklight do |config|
     config.search_builder_class = Hydra::SearchBuilder
     config.default_solr_params = {


### PR DESCRIPTION
These are already added by default in
Blacklight::AccessControls::Enforcement https://github.com/projectblacklight/blacklight-access_controls/blob/master/lib/blacklight/access_controls/enforcement.rb#L20

Note: we should update Dive Into Hydra to remove access controls on the
search builder