### PR TITLE
Don't run the doc task on ci. Fixes #344

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -14,7 +14,6 @@ task :ci => ['engine_cart:generate'] do
   with_test_server do
     Rake::Task['spec'].invoke
   end
-  Rake::Task["doc"].invoke
 end
 
 task :default => [:ci]


### PR DESCRIPTION
It fails the build because RedCloth is not installed. I can't see any reason one would want the doc generated on travis as we can't see the output.