### PR TITLE
Add an empty 'production' key to role_map

### DIFF
--- a/hydra-core/lib/generators/hydra/templates/config/role_map.yml
+++ b/hydra-core/lib/generators/hydra/templates/config/role_map.yml
@@ -1,6 +1,7 @@
 development:
   archivist:
     - archivist1@example.com
+
 test:
   archivist:
     - archivist1@example.com
@@ -17,3 +18,6 @@ test:
   patron:
     - patron1@example.com
     - leland_himself@example.com
+
+production:
+  # Add roles for users here.


### PR DESCRIPTION
So that it doesn't imediately throw a key error when run in production
mode.