### PR TITLE
Pass replacment function to CleanGraphRepository

### DIFF
--- a/hydra-core/app/models/hydra/content_negotiation/clean_graph_repository.rb
+++ b/hydra-core/app/models/hydra/content_negotiation/clean_graph_repository.rb
@@ -2,14 +2,18 @@ module Hydra::ContentNegotiation
   # CleanGraphRepository has a #find interface which returns a graph for use
   # with content negotiation.
   class CleanGraphRepository
-    attr_reader :connection
-    def initialize(connection)
+    attr_reader :connection, :replacer
+    # @param [#get] connection the connection to fedora
+    # @param [#call] replacer a function that is called with id and graph and returns a string representation of the new uri.
+    def initialize(connection, replacer = Hydra.config.id_to_resource_uri)
       @connection = connection
+      @replacer = replacer
     end
 
     def find(id)
       ReplacingGraphFinder.new(
-        GraphFinder.new(connection, id)
+        GraphFinder.new(connection, id),
+        replacer
       ).graph
     end
   end

--- a/hydra-core/app/models/hydra/content_negotiation/fedora_uri_replacer.rb
+++ b/hydra-core/app/models/hydra/content_negotiation/fedora_uri_replacer.rb
@@ -1,9 +1,13 @@
 module Hydra::ContentNegotiation
   # Replaces Fedora URIs in a graph with a Hydra-configured alternative.
   class FedoraUriReplacer
-    def initialize(fedora_base_uri, graph)
+    # @param [String] fedora_base_uri the internal Fedora base uri
+    # @param [RDF::Graph] graph the original graph that needs URIs replaced
+    # @param [#call] replacer a function that is called with id and graph and returns a string representation of the new uri.
+    def initialize(fedora_base_uri, graph, replacer)
       @fedora_base_uri = fedora_base_uri
       @graph = graph
+      @replacer = replacer
     end
 
     def run
@@ -12,11 +16,11 @@ module Hydra::ContentNegotiation
 
     private
 
-    attr_reader :fedora_base_uri, :graph
+    attr_reader :fedora_base_uri, :graph, :replacer
 
     def replace_uri(uri)
       id = ActiveFedora::Base.uri_to_id(uri)
-      RDF::URI(Hydra.config.id_to_resource_uri.call(id, graph))
+      RDF::URI(replacer.call(id, graph))
     end
 
     def replaced_objects

--- a/hydra-core/app/models/hydra/content_negotiation/replacing_graph_finder.rb
+++ b/hydra-core/app/models/hydra/content_negotiation/replacing_graph_finder.rb
@@ -2,6 +2,13 @@ module Hydra::ContentNegotiation
   # Decorator for Finder which replaces Fedora subjects in the graph with a 
   # configured URI
   class ReplacingGraphFinder < SimpleDelegator
+
+    attr_reader :replacer
+    def initialize(graph_finder, replacer)
+      super(graph_finder)
+      @replacer = replacer
+    end
+
     def graph
       graph_replacer.run
     end
@@ -9,7 +16,9 @@ module Hydra::ContentNegotiation
     private
 
     def graph_replacer
-      ::Hydra::ContentNegotiation::FedoraUriReplacer.new(base_uri, __getobj__.graph)
+      ::Hydra::ContentNegotiation::FedoraUriReplacer.new(base_uri,
+                                                         __getobj__.graph,
+                                                         replacer)
     end
 
     def base_uri


### PR DESCRIPTION
This allows us to use a more dyanmic replacement function that has
inputs such as the request context