### PR TITLE
gitignore updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,24 +4,11 @@
 coverage
 rdoc
 pkg
-/.bundle
-db/*.sqlite3
-log/*.log
 tmp/
 console
 
 *.sqlite3
 *.log
-
-log/*
-
-public/plugin_assets
-public/plugin_assets/
-
-tmp/**/*
-tmp/performance
-
-db/schema.rb
 
 .project
 .buildpath


### PR DESCRIPTION
We don't need to ignore that which does not exist.

No need to doubly ignore particular subsets of supersets already ignored.  Especially when neither exists.

A couple other things that do exist we might ignore.