### PR TITLE
Bump blacklight-access_controls version

### DIFF
--- a/hydra-access-controls/hydra-access-controls.gemspec
+++ b/hydra-access-controls/hydra-access-controls.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |gem|
   gem.name          = "hydra-access-controls"
   gem.require_paths = ["lib"]
   gem.version       = version
-  gem.license       = "APACHE2"
+  gem.license       = "APACHE-2.0"
 
   gem.required_ruby_version = '>= 1.9.3'
 
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'cancancan', '~> 1.8'
   gem.add_dependency 'deprecation', '~> 1.0'
   gem.add_dependency "blacklight", '>= 5.16'
-  gem.add_dependency "blacklight-access_controls", '~> 0.5'
+  gem.add_dependency "blacklight-access_controls", '~> 0.6'
 
   gem.add_development_dependency "rake", '~> 10.1'
   gem.add_development_dependency 'rspec', '~> 3.1'


### PR DESCRIPTION
Also adjust formatting of license identification string to match formal recommendations of:
- http://guides.rubygems.org/specification-reference/#license=, referencing
- http://spdx.org/licenses/Apache-2.0.html