### PR TITLE
Create HYDRA_BIND_ALL option to bind to all IPs for `hydra:server` task

### DIFF
--- a/hydra-core/lib/tasks/hydra.rake
+++ b/hydra-core/lib/tasks/hydra.rake
@@ -4,7 +4,8 @@ namespace :hydra do
   desc "Start a solr, fedora and rails instance"
   task :server do
     with_server('development') do
-      IO.popen('rails server') do |io|
+      # Specifying HYDRA_BIND_ALL=true will bind to all IPs
+      IO.popen("rails server #{'-b 0.0.0.0' if ENV['HYDRA_BIND_ALL']}") do |io|
         begin
           io.each do |line|
             puts line


### PR DESCRIPTION
Currently, the `rake hydra:server` task does not work well from VMs.  By default, it binds the `rails server` to `localhost` rather than all IPs (`-b 0.0.0.0`).  When working from a VM, this will mean that external requests (from the host) will not be accepted.

Based on discussion in Slack with @mjgiarlo and @jcoyne, @jcoyne suggested creating an environment variable (`HYDRA_BIND_ALL`) to optionally tell this task to bind to all IPs.

This PR creates that suggested `HYDRA_BIND_ALL` environment variable, so that the behavior is now as follows:
* `rake hydra:server` by default continues to simply bind to `localhost`
* `HYDRA_BIND_ALL=true rake hydra:server` will instead bind to all IPs.  I've tested this option using [hydra-vagrant](https://github.com/projecthydra-labs/hydra-vagrant) and it allows the application running on the VM to now be accessible from the host machine.