### PR TITLE
Update hydra:server to support HOST env variable

### DIFF
--- a/hydra-core/lib/tasks/hydra.rake
+++ b/hydra-core/lib/tasks/hydra.rake
@@ -4,7 +4,9 @@ namespace :hydra do
   desc "Start a solr, fedora and rails instance"
   task :server do
     with_server('development') do
-      IO.popen('rails server') do |io|
+      # If HOST specified, bind to that IP with -b
+      server_options = " -b #{ENV['HOST']}" if ENV['HOST']
+      IO.popen("rails server#{server_options}") do |io|
         begin
           io.each do |line|
             puts line


### PR DESCRIPTION
Based off discussion in #381, this PR updates the `hydra:server` rake task to respect the `HOST` environment variable. The `HOST` environment variable has also been introduced on Rails `master` (see https://github.com/rails/rails/pull/25688). So, this is preemptive support for that new option.

Behavior is now as follows:
- `rake hydra:server` by default continues to simply bind to localhost
- `HOST="0.0.0.0" rake hydra:server` will instead bind to all IPs. I've tested this option using [hydra-vagrant](https://github.com/projecthydra-labs/hydra-vagrant) and it allows the application running on the VM to now be accessible from the host machine.
