### PR TITLE
Remove permissions if they specify delete and update at the same time

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,12 @@
 language: ruby
 sudo: false
-rvm: 2.3.0
+rvm: 2.3.1
 
 matrix:
   include:
-    - rvm: 2.2.4
+    - rvm: 2.3.1
       env: "BLACKLIGHT_VERSION=6.3.1"
-    - rvm: 2.2.4
+    - rvm: 2.3.1
       env: "BLACKLIGHT_VERSION=5.17.2"
 
 notifications:

--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ gem 'rspec-its'
 gemspec
 
 # BEGIN ENGINE_CART BLOCK
-# engine_cart: 0.10.0
+# engine_cart: 1.0.1
 # engine_cart stanza: 0.10.0
 # the below comes from engine_cart, a gem used to test this Rails engine gem in the context of a Rails app.
 file = File.expand_path('Gemfile', ENV['ENGINE_CART_DESTINATION'] || ENV['RAILS_ROOT'] || File.expand_path('.internal_test_app', File.dirname(__FILE__)))

--- a/hydra-access-controls/app/models/concerns/hydra/access_controls/permissions.rb
+++ b/hydra-access-controls/app/models/concerns/hydra/access_controls/permissions.rb
@@ -61,7 +61,9 @@ module Hydra
           prop['id'] = selected.id if selected
         end
 
-        self.permissions_attributes_without_uniqueness = attributes_collection
+        clean_collection = remove_concurrent_deletes(attributes_collection)
+
+        self.permissions_attributes_without_uniqueness = clean_collection
       end
 
       # Return a list of groups that have discover permission
@@ -436,6 +438,18 @@ module Hydra
       def person_agent?(agent)
         raise 'no agent' unless agent.present?
         agent.first.rdf_subject.to_s.start_with?(PERSON_AGENT_URL_PREFIX)
+      end
+
+      # Removes any permissions if both a delete and an update are found for the same id
+      # Fixes https://github.com/projecthydra/sufia/issues/2821
+      def remove_concurrent_deletes(collection)
+        collection.each do |permission|
+          next unless has_destroy_flag?(permission)
+          delete_id = permission.fetch(:id, nil)
+          if collection.map { |c| c if c.fetch(:id, nil) == delete_id }.count > 1
+            collection.delete_if { |permission| permission.fetch(:id, nil) == delete_id }
+          end
+        end
       end
     end
   end

--- a/hydra-access-controls/spec/unit/permissions_spec.rb
+++ b/hydra-access-controls/spec/unit/permissions_spec.rb
@@ -151,6 +151,23 @@ describe Hydra::AccessControls::Permissions do
               expect(reloaded).to eq [{ type: "person", access: "edit", name: "jcoyne" }]
             end
           end
+
+          context "when destroy and update are simultaneously set" do
+            let(:simultaneous) do
+              [
+                { id: permissions_id, type: "group", access: "read", name: "group1", _destroy: '1' },
+                { id: permissions_id, type: "group", access: "read", name: "group1", }
+              ]
+            end
+            before do
+              subject.update permissions_attributes: [{ type: "group", access: "read", name: "group1" }]
+              subject.update permissions_attributes: simultaneous
+            end
+
+            it "leaves the permissions unchanged" do
+              expect(reloaded).to contain_exactly({:name=>"jcoyne", :type=>"person", :access=>"edit"}, {:name=>"group1", :type=>"group", :access=>"read"})
+            end
+          end
         end
 
         context "to a falsy value" do

--- a/hydra-access-controls/spec/unit/permissions_spec.rb
+++ b/hydra-access-controls/spec/unit/permissions_spec.rb
@@ -165,7 +165,20 @@ describe Hydra::AccessControls::Permissions do
             end
 
             it "leaves the permissions unchanged" do
-              expect(reloaded).to contain_exactly({:name=>"jcoyne", :type=>"person", :access=>"edit"}, {:name=>"group1", :type=>"group", :access=>"read"})
+              expect(reloaded).to contain_exactly({name: "jcoyne", type: "person", access: "edit"}, {name: "group1", type: "group", access: "read"})
+            end
+          end
+
+          context "when destroy is present without an id" do
+            let(:missing_id) do
+              [ { type: "group", access: "read", name: "group1", _destroy: '1' } ]
+            end
+            before do
+              subject.update permissions_attributes: missing_id
+            end
+
+            it "leaves the permissions unchanged" do
+              expect(reloaded).to contain_exactly({name: "jcoyne", type: "person", access: "edit"})
             end
           end
         end

--- a/hydra-head.gemspec
+++ b/hydra-head.gemspec
@@ -20,9 +20,9 @@ Gem::Specification.new do |s|
   s.add_dependency 'hydra-access-controls', version
   s.add_dependency 'hydra-core', version
 
-  s.add_development_dependency 'solr_wrapper', '~> 0.5'
-  s.add_development_dependency 'fcrepo_wrapper', '~> 0.2'
-  s.add_development_dependency 'engine_cart', '~> 0.10'
+  s.add_development_dependency 'solr_wrapper', '~> 0.18'
+  s.add_development_dependency 'fcrepo_wrapper', '~> 0.6'
+  s.add_development_dependency 'engine_cart', '~> 1.0'
   s.add_development_dependency 'yard'
   s.add_development_dependency 'rspec-rails'
   s.add_development_dependency 'factory_girl_rails'


### PR DESCRIPTION
Fixes an issue identified in Sufia where the UI allows the user to both delete and add the same permission.
See projecthydra/sufia#2821