### PR TITLE
Escape agent to avoid invalid agent URIs

### DIFF
--- a/hydra-access-controls/app/models/hydra/access_controls/permission.rb
+++ b/hydra-access-controls/app/models/hydra/access_controls/permission.rb
@@ -37,7 +37,7 @@ module Hydra::AccessControls
     end
 
     def agent_name
-      parsed_agent.last
+      URI.decode(parsed_agent.last)
     end
 
     def access
@@ -58,9 +58,9 @@ module Hydra::AccessControls
       raise "Can't build agent #{inspect}" unless name && type
       self.agent = case type
                    when 'group'
-                     Agent.new(::RDF::URI.new("#{GROUP_AGENT_URL_PREFIX}##{name}"))
+                     Agent.new(::RDF::URI.new("#{GROUP_AGENT_URL_PREFIX}##{URI.encode(name)}"))
                    when 'person'
-                     Agent.new(::RDF::URI.new("#{PERSON_AGENT_URL_PREFIX}##{name}"))
+                     Agent.new(::RDF::URI.new("#{PERSON_AGENT_URL_PREFIX}##{URI.encode(name)}"))
                    else
                      raise ArgumentError, "Unknown agent type #{type.inspect}"
                    end

--- a/hydra-access-controls/app/models/hydra/access_controls/permission.rb
+++ b/hydra-access-controls/app/models/hydra/access_controls/permission.rb
@@ -58,12 +58,16 @@ module Hydra::AccessControls
       raise "Can't build agent #{inspect}" unless name && type
       self.agent = case type
                    when 'group'
-                     Agent.new(::RDF::URI.new("#{GROUP_AGENT_URL_PREFIX}##{URI.encode(name)}"))
+                     build_agent_resource(GROUP_AGENT_URL_PREFIX, name)
                    when 'person'
-                     Agent.new(::RDF::URI.new("#{PERSON_AGENT_URL_PREFIX}##{URI.encode(name)}"))
+                     build_agent_resource(PERSON_AGENT_URL_PREFIX, name)
                    else
                      raise ArgumentError, "Unknown agent type #{type.inspect}"
                    end
+    end
+
+    def build_agent_resource(prefix, name)
+      Agent.new(::RDF::URI.new("#{prefix}##{URI.encode(name)}"))
     end
 
     def build_access(access)

--- a/hydra-access-controls/spec/unit/permission_spec.rb
+++ b/hydra-access-controls/spec/unit/permission_spec.rb
@@ -45,4 +45,19 @@ describe Hydra::AccessControls::Permission do
       expect(perm2).to_not eq perm3
     end
   end
+
+  describe "URI escaping" do
+    let(:permission) { described_class.new(type: 'person', name: 'john doe', access: 'read') }
+    let(:permission2) { described_class.new(type: 'group', name: 'hydra devs', access: 'read') }
+
+    it "should escape agent when building" do
+      expect(permission.agent.first.rdf_subject.to_s).to eq 'http://projecthydra.org/ns/auth/person#john%20doe'
+      expect(permission2.agent.first.rdf_subject.to_s).to eq 'http://projecthydra.org/ns/auth/group#hydra%20devs'
+    end
+
+    it "should unescape agent when parsing" do
+      expect(permission.agent_name).to eq 'john doe'
+      expect(permission2.agent_name).to eq 'hydra devs'
+    end
+  end
 end


### PR DESCRIPTION
Because the validation flag isn't set in the call to RDF::URI.new it is possible to save an invalid URI if you have an agent with a space it it's name (e.g. 'John Doe' or 'Hydra developers').  In this case, reading the permissions back on the owning AF::Base object throws a RuntimeError of 'no agent'.  This PR escapes the agent name when building the URI and decodes it on read.