### PR TITLE
compare entire timestamps of embargo_release_date and current time wh…

### DIFF
--- a/hydra-access-controls/app/models/hydra/permissions_solr_document.rb
+++ b/hydra-access-controls/app/models/hydra/permissions_solr_document.rb
@@ -3,8 +3,8 @@ class Hydra::PermissionsSolrDocument < SolrDocument
     #permissions = permissions_doc(params[:id])
     embargo_key = Hydra.config.permissions.embargo.release_date
     if self[embargo_key]
-      embargo_date = Date.parse(self[embargo_key].split(/T/)[0])
-      return embargo_date > Date.parse(Time.now.to_s)
+      embargo_date = DateTime.parse(self[embargo_key])
+      return embargo_date > DateTime.parse(Time.now.to_s)
     end
     false
   end


### PR DESCRIPTION
…en checking embargoes

Existing logic checks for date only and it may cause issue with embargo lifting, and giving false status on the embargo release date. 