### PR TITLE
Recent change to Permission class removed automatic string interpolation on `name` argument.

### DIFF
--- a/hydra-access-controls/app/models/hydra/access_controls/permission.rb
+++ b/hydra-access-controls/app/models/hydra/access_controls/permission.rb
@@ -5,9 +5,13 @@ module Hydra::AccessControls
   class Permission < AccessControlList
     has_many :admin_policies, inverse_of: :default_permissions, class_name: 'Hydra::AdminPolicy'
 
+    # @param [Hash] args
+    # @option args [#to_s] :name name of agent
+    # @option args [#to_s] :type type of agent: group/person
+    # @option args [String] :access description of access: read/edit/discover
     def initialize(args)
       super()
-      build_agent(args[:name], args[:type].to_s)
+      build_agent(args[:name].to_s, args[:type].to_s)
       build_access(args[:access])
     end
 

--- a/hydra-access-controls/spec/unit/permission_spec.rb
+++ b/hydra-access-controls/spec/unit/permission_spec.rb
@@ -59,5 +59,14 @@ describe Hydra::AccessControls::Permission do
       expect(permission.agent_name).to eq 'john doe'
       expect(permission2.agent_name).to eq 'hydra devs'
     end
+
+    context 'with a User instance passed as :name argument' do
+      let(:permission) { described_class.new(type: 'person', name: user, access: 'read') }
+      let(:user) { FactoryGirl.create(:archivist) }
+
+      it "should use string and escape agent when building" do
+        expect(permission.agent.first.rdf_subject.to_s).to eq 'http://projecthydra.org/ns/auth/person#archivist1@example.com'
+      end
+    end
   end
 end


### PR DESCRIPTION
This coerces the arg to a string early so that it can be URI encoded later.