### PR TITLE
Remove registered pseudo-group from RoleMapper

### DIFF
--- a/hydra-access-controls/lib/hydra/role_mapper_behavior.rb
+++ b/hydra-access-controls/lib/hydra/role_mapper_behavior.rb
@@ -17,9 +17,7 @@ module Hydra::RoleMapperBehavior
         user = user_or_uid
         user_id = user.user_key
       end
-      array = byname[user_id].dup || []
-      array = array << 'registered' unless (user.nil? || user.new_record?)
-      array
+      byname[user_id].dup || []
     end
 
     def whois(r)

--- a/hydra-access-controls/spec/unit/role_mapper_spec.rb
+++ b/hydra-access-controls/spec/unit/role_mapper_spec.rb
@@ -16,8 +16,8 @@ describe RoleMapper do
   it "doesn't change its response when it's called repeatedly" do
     u = User.new(:uid=>'leland_himself@example.com')
     allow(u).to receive(:new_record?).and_return(false)
-    expect(RoleMapper.roles(u).sort).to eq ['archivist', 'donor', 'patron', "registered"]
-    expect(RoleMapper.roles(u).sort).to eq ['archivist', 'donor', 'patron', "registered"]
+    expect(RoleMapper.roles(u).sort).to eq ['archivist', 'donor', 'patron']
+    expect(RoleMapper.roles(u).sort).to eq ['archivist', 'donor', 'patron']
   end
 
   it "returns an empty array if there are no roles" do


### PR DESCRIPTION
It's added by blacklight-access-control here:
https://github.com/projectblacklight/blacklight-access_controls/blob/f0b003ef6006b778c460d2b399c026d3b92052cf/lib/blacklight/access_controls/ability.rb#L102