### PR TITLE
Use the new way of running controller tests

### DIFF
--- a/hydra-core/spec/controllers/catalog_controller_spec.rb
+++ b/hydra-core/spec/controllers/catalog_controller_spec.rb
@@ -6,7 +6,7 @@ describe CatalogController do
     session[:user]='bob'
   end
 
-  it "should use CatalogController" do
+  it "uses the CatalogController" do
     expect(controller).to be_an_instance_of CatalogController
   end
 
@@ -47,8 +47,8 @@ describe CatalogController do
         allow(controller).to receive(:enforce_show_permissions)
       end
       context "with no asset" do
-        it "should return a not found response code" do
-          get 'show', :id => "test", :format => :nt
+        it "returns a not found response code" do
+          get 'show', params: { id: "test", format: :nt }
 
           expect(response).to be_not_found
         end
@@ -66,35 +66,39 @@ describe CatalogController do
         let(:related) do
           ActiveFedora::Base.create
         end
-        it "should be able to negotiate jsonld" do
-          get 'show', :id => asset.id, :format => :jsonld
+        it "is able to negotiate jsonld" do
+          get 'show', params: { id: asset.id, format: :jsonld }
 
           expect(response).to be_success
           expect(response.headers['Content-Type']).to include("application/ld+json")
           graph = RDF::Reader.for(:jsonld).new(response.body)
           expect(graph.statements.to_a.length).to eq 3
         end
-        it "should be able to negotiate ttl" do
-          get 'show', :id => asset.id, :format => :ttl
+
+        it "is able to negotiate ttl" do
+          get 'show', params: { id: asset.id, format: :ttl }
           
           expect(response).to be_success
           graph = RDF::Reader.for(:ttl).new(response.body)
           expect(graph.statements.to_a.length).to eq 3
         end
-        it "should return an n-triples graph with just the content put in" do
-          get 'show', :id => asset.id, :format => :nt
+
+        it "returns an n-triples graph with just the content put in" do
+          get 'show', params: { id: asset.id, format: :nt }
 
           graph = RDF::Reader.for(:ntriples).new(response.body)
           statements = graph.statements.to_a
           expect(statements.length).to eq 3
           expect(statements.first.subject).to eq asset.rdf_subject
         end
+
         context "with a configured subject converter" do
           before do
             Hydra.config.id_to_resource_uri = lambda { |id, _| "http://hydra.box/catalog/#{id}" }
-            get 'show', :id => asset.id, :format => :nt
+            get 'show', params: { id: asset.id, format: :nt }
           end
-          it "should convert it" do
+
+          it "converts the subject using the specified converter" do
             graph = RDF::Graph.new << RDF::Reader.for(:ntriples).new(response.body)
             title_statement = graph.query([nil, RDF::Vocab::DC.title, nil]).first
             related_statement = graph.query([nil, RDF::Vocab::DC.isReferencedBy, nil]).first
@@ -108,10 +112,10 @@ describe CatalogController do
 
   describe "filters" do
     describe "show" do
-      it "should trigger enforce_show_permissions" do
+      it "triggers enforce_show_permissions" do
         allow(controller).to receive(:current_user).and_return(nil)
         expect(controller).to receive(:enforce_show_permissions)
-        get :show, id: 'test:3'
+        get :show, params: { id: 'test:3' }
       end
     end
   end


### PR DESCRIPTION
This removes these deprecation warnings:
```
DEPRECATION WARNING: ActionController::TestCase HTTP request methods
will accept only keyword arguments in future Rails versions.
```