### PR TITLE
Clear cache when removing permissions

### DIFF
--- a/hydra-access-controls/app/models/concerns/hydra/access_controls/permissions.rb
+++ b/hydra-access-controls/app/models/concerns/hydra/access_controls/permissions.rb
@@ -415,10 +415,10 @@ module Hydra
 
       # @param [RDF::URI] mode One of the permissions modes, e.g. ACL.Write, ACL.Read, etc.
       # @yieldparam [Array<ActiveFedora::Base>] agent the agent type assertions
-      # @return [Array<Permission>] list of permissions where the mode is as selected, the block evaluates to true and the target is not marked for delete
+      # @return [Array<Permission>] list of permissions where the mode is as selected, the block evaluates to true
       def search_by_mode(mode)
         permissions.to_a.select do |p|
-          yield(p.agent) && !p.marked_for_destruction? && p.mode.first.rdf_subject == mode
+          yield(p.agent) && p.mode.first.rdf_subject == mode
         end
       end
 

--- a/hydra-access-controls/spec/unit/permissions_spec.rb
+++ b/hydra-access-controls/spec/unit/permissions_spec.rb
@@ -134,6 +134,7 @@ describe Hydra::AccessControls::Permissions do
             it "removes permissions on existing users" do
               indexed_result = ActiveFedora::SolrService.query("id:#{subject.id}").first['edit_access_person_ssim']
               expect(indexed_result).to eq ['jcoyne']
+              expect(subject.permissions.map(&:to_hash)).to eq [{ name: "jcoyne", type: "person", access: "edit" }]
               expect(reloaded).to eq [{ name: "jcoyne", type: "person", access: "edit" }]
             end
           end
@@ -188,7 +189,7 @@ describe Hydra::AccessControls::Permissions do
               subject.update permissions_attributes: [
                 { id: permissions_id, type: "group", access: "read", name: "group1", _destroy: '1' },
                 { type: "group", access: "edit", name: "group2" },
-                { type: "person", access: "read", name: "joebob" } 
+                { type: "person", access: "read", name: "joebob" }
               ]
             end
 


### PR DESCRIPTION
Prevents `object.permissions` from returning rows that have been
destroyed.

Ref https://github.com/projecthydra/sufia/issues/3033
Ref https://github.com/projecthydra/sufia/issues/2820