### PR TITLE
Adding `it_behaves_like 'a Hydra group_service interface'`

### DIFF
--- a/hydra-access-controls/lib/hydra/shared_spec/group_service_interface.rb
+++ b/hydra-access-controls/lib/hydra/shared_spec/group_service_interface.rb
@@ -1,0 +1,16 @@
+RSpec.shared_examples 'a Hydra group_service interface' do
+  before do
+    raise 'adapter must be set with `let(:group_service)`' unless
+      defined? group_service
+  end
+
+  subject { group_service }
+
+  it { is_expected.to respond_to(:role_names).with(0).arguments }
+
+  describe '#fetch_groups' do
+    it 'requires a user: keyword arg' do
+      expect(group_service.method(:fetch_groups).parameters).to eq([[:keyreq, :user]])
+    end
+  end
+end

--- a/hydra-access-controls/spec/unit/role_mapper_spec.rb
+++ b/hydra-access-controls/spec/unit/role_mapper_spec.rb
@@ -1,9 +1,13 @@
 require 'spec_helper'
+require 'hydra/shared_spec/group_service_interface'
 
 describe RoleMapper do
   it "defines the 4 roles" do
     expect(RoleMapper.role_names.sort).to eq %w(admin_policy_object_editor archivist donor patron researcher)
   end
+
+  let(:group_service) { described_class }
+  it_behaves_like 'a Hydra group_service interface'
 
   describe "#whois" do
     it "knows who is what" do
@@ -14,7 +18,7 @@ describe RoleMapper do
   end
 
   describe "fetch_groups" do
-    let(:user) { instance_double(User, user_key: email, new_record?: false) } 
+    let(:user) { instance_double(User, user_key: email, new_record?: false) }
     subject { RoleMapper.fetch_groups(user: user) }
 
     context "for a user with multiple roles" do
@@ -26,7 +30,7 @@ describe RoleMapper do
         expect(RoleMapper.fetch_groups(user: user)).to match_array ['archivist', 'donor', 'patron']
       end
     end
-      
+
     context "for a user with a single role" do
       let(:email) { 'archivist2@example.com' }
       it { is_expected.to match_array ['archivist'] }

--- a/hydra-core/spec/models/user_spec.rb
+++ b/hydra-core/spec/models/user_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'hydra/shared_spec/group_service_interface'
 
 describe User do
 
@@ -23,6 +24,11 @@ describe User do
         expect(subject).to eq 'foo'
       end
     end
+  end
+
+  describe '.group_service' do
+    let(:group_service) { described_class.group_service }
+    it_behaves_like 'a Hydra group_service interface'
   end
 
   describe "#groups" do


### PR DESCRIPTION
We are working at pushing Hyku's rolify behavior into the
`User.group_service` interface. This is our first step to begin to
better enforce the interface of the group service.