### PR TITLE
generator should install rspec

### DIFF
--- a/hydra-core/lib/generators/hydra/head_generator.rb
+++ b/hydra-core/lib/generators/hydra/head_generator.rb
@@ -33,14 +33,9 @@ module Hydra
       end
     end
 
-    def inject_test_framework
+    def install_rspec
       return if options[:'skip-rspec']
-
-      application("\n" <<
-        "    config.generators do |g|\n" <<
-        "      g.test_framework :rspec, :spec => true\n" <<
-        "    end\n\n"
-      )
+      generate 'rspec:install'
     end
 
     def overwrite_catalog_controller


### PR DESCRIPTION
Fixes #409 

I placed this in the `ingest_test_framework` method since it seemed most relevant there. Please let me know if it should instead go in its own method. 